### PR TITLE
docs: add MCP Server section and announcement banner

### DIFF
--- a/source/includes/_mcp_server.md
+++ b/source/includes/_mcp_server.md
@@ -1,0 +1,37 @@
+# MCP Server<span class="tag-new"></span>
+
+```json
+// Claude Desktop / Claude Code / Cursor / VS Code
+{
+  "mcpServers": {
+    "delta-exchange": {
+      "command": "uvx",
+      "args": ["delta-exchange-mcp"],
+      "env": {
+        "DELTA_API_KEY": "your_api_key",
+        "DELTA_API_SECRET": "your_api_secret"
+      }
+    }
+  }
+}
+```
+
+The Delta Exchange MCP server exposes this API to AI agents over the Model Context Protocol. It runs as a local stdio subprocess and turns agent tool calls into signed REST requests. An agent reads market data, checks an account and places orders without writing HTTP or signing code.
+
+Install and run it with `uvx delta-exchange-mcp`. Its tools fall into three tiers:
+
+| Category | API key | Permissions | What an agent can do |
+| --- | --- | --- | --- |
+| Market data | Not required | — | Read the product catalog, tickers, order-book depth, recent trades and OHLC candles. Pull option chains, spot indices, settlement prices, and funding-rate, mark-price and open-interest history. |
+| Account data | Required | Read permission | Read open positions with size, entry and unrealized PnL. Read balances, the wallet ledger, active and past orders, own fills, leverage and account preferences. Export fills to CSV. |
+| Trading | Required | Trading permission + `DELTA_MCP_MODE=trade` | Place, edit and cancel single orders, batches of up to 50 on one contract, and take-profit/stop-loss brackets. Set leverage, adjust isolated margin, close all positions. |
+
+Every tool is a read-only `GET` by default. The trading tools register only when you set `DELTA_MCP_MODE=trade` and supply an API key with trading permissions.
+
+Once connected, ask the agent in plain language:
+
+- "What is my unrealized PnL on BTCUSD?"
+- "Show the BTC option chain expiring this Friday."
+- "Cancel my open orders on ETHUSD." (trade mode only)
+
+For setup, the full tool reference and key permissions, see [mcp.delta.exchange/docs](https://mcp.delta.exchange/docs).

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -25,6 +25,7 @@ We have language bindings in Shell, Python, Ruby and Nodejs! You can view code e
 <%= partial "includes/_system_status" %>
 <%= partial "includes/_types" %>
 <%= partial "includes/_response_formats" %>
+<%= partial "includes/_mcp_server" %>
 <%= partial "includes/_rest_api" %>
 <%= partial "includes/_deadman_switch" %>
 <%= partial "includes/_place_order_error_codes" %>

--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -2,6 +2,7 @@
 //= require ./app/_toc
 //= require ./app/_lang
 //= require ./app/_download
+//= require ./app/_banner
 
 $(function() {
   loadToc($('#toc'), '.toc-link', '.toc-list-h2', 10);

--- a/source/javascripts/app/_banner.js
+++ b/source/javascripts/app/_banner.js
@@ -1,0 +1,23 @@
+;(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'slateBannerDismissed';
+
+  $(function() {
+    $('#announce-close').on('click', function() {
+      $('#announce-banner').remove();
+      document.documentElement.className += ' banner-hidden';
+
+      try {
+        localStorage.setItem(STORAGE_KEY, '1');
+      } catch (e) {}
+
+      // every heading moved up by the banner height, so the ToC's cached
+      // offsets are stale
+      if (window.recacheHeights) {
+        window.recacheHeights();
+        window.refreshToc();
+      }
+    });
+  });
+})();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -30,6 +30,15 @@ under the License.
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
+    <script>
+      // Applied before paint so a dismissed banner never flashes: the JS bundle
+      // below loads in <head>, but its ready handler runs after the first paint.
+      try {
+        if (localStorage.getItem('slateBannerDismissed') === '1') {
+          document.documentElement.className += ' banner-hidden';
+        }
+      } catch (e) {}
+    </script>
     <%= favicon_tag 'images/favicon.svg' %>
     <style>
       <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>
@@ -44,6 +53,12 @@ under the License.
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
+    <div class="announce-banner" id="announce-banner">
+      <span class="tag-new"></span>
+      <span class="announce-text">Delta Exchange MCP Server &mdash; call API endpoints from your AI agents</span>
+      <a href="https://mcp.delta.exchange/docs" target="_blank" rel="noopener" class="announce-cta">Read more &rarr;</a>
+      <button type="button" class="announce-close" id="announce-close" aria-label="Dismiss announcement">&times;</button>
+    </div>
     <a href="#" id="nav-button">
       <span>
         NAV

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -51,6 +51,7 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 // SIZES
 ////////////////////
 $nav-width: 230px !default; // width of the navbar
+$banner-height: 44px !default; // height of the fixed announcement banner
 $examples-width: 30% !default; // portion of the screen taken up by code examples
 $logo-margin: 10px !default; // margin below logo
 $main-padding: 28px !default; // padding to left and right of content & examples

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -38,6 +38,115 @@ body {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// ANNOUNCEMENT BANNER
+////////////////////////////////////////////////////////////////////////////////
+// Fixed to the top of the viewport, over the nav sidebar and the content. Every
+// other fixed element in this file assumes the viewport starts at y=0, so each
+// one is offset by $banner-height below and reset again under .banner-hidden.
+
+html {
+  // so an anchor target lands below the banner instead of under it
+  scroll-padding-top: $banner-height + 10px;
+}
+
+body {
+  padding-top: $banner-height;
+  box-sizing: border-box; // keep the padding inside the existing height: 100%
+}
+
+// "new" pill. The label is CSS content, so heading ids, nav titles and the
+// search index stay clean. Shared by the banner and section headings; each
+// context supplies its own spacing.
+.tag-new::after {
+  content: "new";
+  background-color: $nav-active-bg;
+  color: $nav-active-text;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.announce-banner {
+  position: fixed;
+  z-index: 40; // over .toc-wrapper (30), under #nav-button (100)
+  top: 0;
+  left: 0;
+  right: 0;
+  height: $banner-height;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding: 0 $main-padding;
+  background-color: $nav-bg;
+  border-bottom: 2px solid $nav-active-bg;
+  color: $nav-text;
+  font-size: 13px;
+
+  .tag-new::after {
+    margin-right: 10px;
+  }
+
+  .announce-text {
+    margin-right: 10px;
+  }
+
+  .announce-cta {
+    color: $nav-text;
+    font-weight: bold;
+    text-decoration: underline;
+    white-space: nowrap;
+  }
+
+  .announce-close {
+    margin-left: auto;
+    padding: 0 0 2px 10px;
+    border: 0;
+    background: none;
+    color: $nav-text;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $nav-text;
+      outline-offset: 2px;
+    }
+  }
+}
+
+.banner-hidden {
+  scroll-padding-top: 10px;
+
+  body {
+    padding-top: 0;
+  }
+
+  .announce-banner {
+    display: none;
+  }
+
+  .toc-wrapper,
+  #nav-button {
+    top: 0;
+  }
+}
+
+@media (max-width: $phone-width) {
+  // keep the bar on one line so the offsets above stay correct
+  .announce-banner .announce-text {
+    display: none;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // TABLE OF CONTENTS
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -55,7 +164,7 @@ body {
   overflow-x: hidden;
   position: fixed;
   z-index: 30;
-  top: 0;
+  top: $banner-height;
   left: 0;
   bottom: 0;
   width: $nav-width;
@@ -270,7 +379,7 @@ body {
   padding: 0 1.5em 5em 0; // increase touch size area
   display: none;
   position: fixed;
-  top: 0;
+  top: $banner-height;
   left: 0;
   z-index: 100;
   color: #000;
@@ -425,6 +534,11 @@ body {
   div:first-child + h1 {
     border-top-width: 0;
     margin-top: 0;
+  }
+
+  .tag-new::after {
+    margin-left: 8px;
+    vertical-align: 2px;
   }
 
   h2 {


### PR DESCRIPTION
## What

Adds a top-level **MCP Server** section to the REST docs, introducing the official Delta Exchange MCP server, plus a dismissible announcement banner pointing at it.

**Live preview:** https://delta-api-docs-mcp.vercel.app

The preview was built before the last edit in this branch, so it still renders "It ships 40 tools in three tiers" where the PR now reads "Its tools fall into three tiers". Everything else on the page matches.

## The section

New partial `source/includes/_mcp_server.md`, included between `_response_formats` and `_rest_api` in `source/index.html.md.erb`. It becomes its own left-nav entry at `#mcp-server` — Slate builds the nav from H1/H2 via `lib/toc_data.rb`, so no nav manifest changes.

Contents:
- The `uvx delta-exchange-mcp` install line and a JSON `mcpServers` client config.
- A capability table — **Category / API key / Permissions / What an agent can do** — for the three tool tiers: Market data (no key), Account data (Read permission), Trading (Trading permission + `DELTA_MCP_MODE=trade`).
- Three example agent prompts.
- A link to the full reference at [mcp.delta.exchange/docs](https://mcp.delta.exchange/docs).

The table describes capabilities rather than listing tool names, and carries no tool count, so it does not go stale on every server release. Setup detail, the full tool reference and the trading guardrails live on the MCP docs site and are deliberately not duplicated here.

## The banner

`.announce-banner` in `source/layouts/layout.erb`, first child of `<body>`: a **new** pill, one line of copy, a `Read more` link to `mcp.delta.exchange/docs`, and a dismiss `×`.

Slate's fixed elements all assume the viewport starts at y=0. One `$banner-height: 44px` variable in `_variables.scss` drives all four affected offsets: `body{padding-top}` (with `box-sizing: border-box`, because `html, body` are `height: 100%`), `.toc-wrapper{top}`, `#nav-button{top}`, and `html{scroll-padding-top}` so anchors do not land under the bar.

Dismissal writes `localStorage.slateBannerDismissed`. An inline `<head>` script re-applies `.banner-hidden` on `<html>` before paint — the bundle loads in `<head>` but jQuery ready runs after, so without the inline script the bar would flash for readers who already dismissed it. `.banner-hidden` resets all four offsets. `_banner.js` calls the theme's existing `window.recacheHeights()` / `refreshToc()` so the ToC's cached header offsets follow the reflow.

Known ceiling: `loadToc(..., 10)` in `all_nosearch.js` is left as-is, so active-link detection fires 44px early. Not visible in use, and changing it means rewriting upstream theme JS.

## Verification

Measured against a build of unmodified `master` as the baseline:

| Gate | Result |
| --- | --- |
| axe-core | 1299 issues, **no serious or critical**. Byte-identical count to baseline; no violation names the banner. The volume is upstream Slate `scrollable-region-focusable` on 1500+ code-sample tabs. |
| Lighthouse CLS | **0.000**, twice. The layout-shift risk of a fixed bar did not materialise. |
| Lighthouse a11y | 77, up from 67 on baseline. |
| Lighthouse perf | 92/93, LCP 2140/1792ms — within baseline run-to-run swing. |
| Readability | Flesch-Kincaid 10.3. |

Both outbound links return HTTP 200.

## Note for whoever merges

Nothing expires the **new** pill. Remove `<span class="tag-new"></span>` from the heading, and the banner block from `layout.erb`, once the section is no longer new. The `.tag-new` rule can stay for reuse.
