### PR TITLE
fix: strip widdershins front matter from the generated REST partial

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,20 @@ run_build() {
   ruby generate_combined_markdown.rb
 }
 
+# Widdershins writes a standalone Slate page, so its output starts with a YAML
+# front matter block. This file is included as a Middleman partial
+# (`<%= partial "includes/_rest_api" %>` in source/index.html.md.erb), and the
+# partial helper does not strip front matter, so the block renders as body text
+# between the previous section and the "Rest Api" heading. Remove it.
+strip_front_matter() {
+  ruby -e '
+    path = ARGV[0]
+    src  = File.read(path)
+    out  = src.sub(/\A---\r?\n.*?\r?\n---\r?\n\s*/m, "")
+    File.write(path, out) unless out == src
+  ' "$1"
+}
+
 parse_args() {
   # Set args from a local environment file.
   if [ -e ".env" ]; then
@@ -219,6 +233,7 @@ elif [[ $1 = --push-only ]]; then
   main "$@"
 elif [[ $1 = --gen-widdershins ]]; then
   widdershins --search true --language_tabs 'python:Python' 'shell:Shell' 'ruby:Ruby' --user_templates widdershins_templates/openapi3  --customApiKeyValue '****'  --summary swagger_v2.json -o source/includes/_rest_api.md
+  strip_front_matter source/includes/_rest_api.md
 else
   run_build
   main "$@"


### PR DESCRIPTION
## The bug

https://docs.delta.exchange/ renders a block of raw YAML as body text, just above the **Rest Api** heading:

> title: Delta Exchange Api V2 v1.0.0 language_tabs: - python: Python - shell: Shell - ruby: Ruby language_clients: - python: "" - shell: "" - ruby: "" toc_footers: [] includes: [] search: true highlight_theme: darkula headingLevel: 2

It renders as `<hr>` + `<p>YAML</p>` + `<hr>`.

## This is not a regression from #128

The same block, byte for byte, is in the deploy before #128. Both `gh-pages` commits contain exactly one occurrence:

| `gh-pages` deploy | Merged | `headingLevel` occurrences |
| --- | --- | --- |
| `89dfe704` (2026-08-05) | #127 | 1 |
| `4efb7508` (2026-08-07) | #128 | 1 |

Before #128 the block sat immediately after the large JSON sample at the end of Response Formats, where it read as part of that code block's noise. #128 inserted a short section between Response Formats and Rest Api, so the block now lands in clean whitespace and is obvious. #128 changed where it is visible, not whether it exists.

## Root cause

`.circleci/config.yml` runs `./deploy.sh --gen-widdershins` on every push to `master`, which regenerates `source/includes/_rest_api.md` from `swagger_v2.json`. Widdershins writes a **standalone Slate page**, so its output opens with a YAML front matter block. Every key in the rendered text is accounted for:

- `title: Delta Exchange Api V2 v1.0.0` — `swagger_v2.json` `info.title` + `info.version`
- `language_tabs` and `search: true` — the `--language_tabs` and `--search true` flags in `deploy.sh`
- `language_clients`, `toc_footers`, `includes`, `highlight_theme`, `headingLevel` — widdershins defaults

That file is then pulled in as a Middleman **partial** — `<%= partial "includes/_rest_api" %>` in `source/index.html.md.erb`. The `partial` helper renders through Tilt and does not extract front matter, so the block reaches the Markdown renderer as ordinary text.

The front matter cannot be turned off through `--user_templates`: `grep -rl 'headingLevel\|language_clients\|toc_footers' widdershins_templates/` returns nothing, because widdershins builds that header in its core.

The copy of `source/includes/_rest_api.md` committed to `master` has no front matter — it starts at `<h1 id="ApiSection">`. It was stripped by hand once. CI overwrites the file on every deploy, so the committed version never reaches production.

## The fix

Strip the block in `deploy.sh` immediately after widdershins writes the file. One place covers both CI and the local `run.sh` path.

Ruby rather than `sed -i`, because that flag takes a mandatory argument on macOS/BSD and none on GNU, and `run.sh` is a developer-facing macOS path while CI is Linux. The repo already requires Ruby and CI runs `cimg/ruby:2.6.10-node`.

The pattern is anchored at the start of the file and matches only up to the **first** closing delimiter, so a `---` inside the API body cannot be mistaken for the terminator. It no-ops when there is no front matter, so it is safe to run twice and safe if widdershins ever stops emitting the block.

## Verification

Ran the real command with widdershins 4.0.1 against `master`:

1. **Reproduced.** After the unpatched `widdershins ... -o source/includes/_rest_api.md`, the file starts with `---` and contains 1 `headingLevel` — matching the live page exactly.
2. **Fixed.** After the patched `./deploy.sh --gen-widdershins`: exit 0, file starts with `<h1 id="ApiSection" class="section-header">Rest Api</h1>`, 0 occurrences of `headingLevel`, no leading `---`.
3. **Idempotent.** Second full run of `./deploy.sh --gen-widdershins`: exit 0, still 0 occurrences. Running the strip against an already-stripped file exits 0 under `set -o errexit` and leaves the checksum unchanged.
4. **`bash -n deploy.sh`** passes.

## One thing worth knowing, not fixed here

The committed `source/includes/_rest_api.md` is 659 lines behind what CI generates — it predates the `Description` columns on the enum tables, among other drift. The live site already serves the newer generated content (`grep -c "Deposits are currently allowed for the asset"` returns 5 on docs.delta.exchange and 0 in the committed file), so nothing is broken by it. Left alone deliberately: refreshing it would bury this 15-line fix under a 2200-line diff. Worth a separate cleanup, or removing the file from version control since CI regenerates it regardless.